### PR TITLE
Decrease run time by ~40%

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -16,7 +16,7 @@ jobs:
           TAG: 'my-optional-tag-name'
           DOCKERFILE_PATH: '.github/docker/Dockerfile'
           BUILD_CONTEXT: '.'
-          DOCKERHUB_REPOSITORY: 'pinkrobin/gpr-docker-publish-example'
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_REPOSITORY: 'eyal0/gpr-docker-publish-example'
+          DOCKERHUB_USERNAME: eyal0
         env:
           REGISTRY_TOKEN: ${{ secrets.DOCKERHUB_PAT }}

--- a/.github/workflows/gpr.yaml
+++ b/.github/workflows/gpr.yaml
@@ -19,3 +19,13 @@ jobs:
         BUILD_CONTEXT: '.'
       env:
         REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish Docker Image to GPR
+      uses: ./
+      with:
+        DOCKERFILE_PATH: 'Dockerfile'
+        BUILD_CONTEXT: '.'
+        DOCKERHUB_REPOSITORY: 'eyal0/gpr-easycov-coverage'
+        DOCKERHUB_USERNAME: 'eyal0'
+        cache: true
+      env:
+        REGISTRY_TOKEN: ${{ secrets.DOCKERHUB_PAT }}

--- a/action.yml
+++ b/action.yml
@@ -36,4 +36,4 @@ branding:
   icon: 'layers'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://eyal0/gpr-easycov-coverage'


### PR DESCRIPTION
I was able to decrease the runtime by 40% by pushing the docker image to dockerhub and using that instead of building it each time.  You can compare the third step here:

https://github.com/eyal0/gpr-docker-publish/commit/12b41495371a82485f0fb9421e207b1b3aa245f6/checks?check_suite_id=365201366

With here:

https://github.com/saubermacherag/gpr-docker-publish/commit/ed381301db93a2e8f6c72e30d17a02413bdf4fda/checks?check_suite_id=327400260

You'll need to do some modification so that it will push to your own dockerhub repo and not mine.  Just swap "eyal0" with whatever name you use in dockerhub.